### PR TITLE
Redirect to event after sign in and other fixes

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
 
       self.current_user = authorization.user
 
-      redirect_to after_login_path, notice: t("sessions.sign_in.success")
+      redirect_to request.env['omniauth.origin'] || '/'
     end
   end
 
@@ -22,11 +22,4 @@ class SessionsController < ApplicationController
 
     redirect_to root_path, notice: t("sessions.sign_out.success")
   end
-
-private
-
-  def after_login_path
-    session.delete(:wants_page) || root_path
-  end
-
 end

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-ALasOcho::Application.config.secret_token = ALasOcho.config.application_config_secret_token
+ALasOcho::Application.config.secret_token = ALasOcho.config["application_config_secret_token"]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,29 @@
+development: &default
+  twitter:
+    consumer_key: 51603471e12723ea91da5c8a1cd3fc39
+    consumer_secret: 51603471e12723ea91da5c8a1cd3fc39
+  facebook:
+    api_key: 51603471e12723ea91da5c8a1cd3fc39
+    api_secret: 51603471e12723ea91da5c8a1cd3fc39
+  google:
+    consumer_key: anonymous
+    consumer_secret: anonymous
+  canonical_host: alasocho.local:3000
+  token_secret: 51603471e12723ea91da5c8a1cd3fc39
+  application_config_secret_token: 51603471e12723ea91da5c8a1cd3fc39
+
+test:
+  << : *default
+
+production:
+  << : *default
+  twitter:
+    consumer_key: key
+    consumer_secret: secret
+  facebook:
+    api_key: key
+    api_secret: secret
+  google:
+    consumer_key: alasocho.com
+    consumer_secret: secret
+  canonical_host: alasocho.com


### PR DESCRIPTION
- Redirect to event after sign in
- Fix secret_token config key
- Commit a `settings.yml` file ready to be used locally against google anonymous app for local development
