### PR TITLE
Confirmed users are notified on declines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,6 @@ group :test do
 end
 
 group :development, :test do
-  gem "ruby-debug19"
+  gem "debugger"
   gem "rspec-rails", "~> 2.6"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,6 @@ GEM
     activesupport (3.1.1)
       multi_json (~> 1.0)
     addressable (2.2.6)
-    archive-tar-minitar (0.5.2)
     arel (2.2.1)
     backbone-rails (0.5.2)
       rails (>= 3.0.0)
@@ -54,9 +53,15 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.1.2)
-    columnize (0.3.4)
+    columnize (0.3.6)
     configuration (1.2.0)
     daemons (1.1.4)
+    debugger (1.5.0)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.2.0)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.2.0)
     diff-lcs (1.1.3)
     erubis (2.7.0)
     execjs (1.2.4)
@@ -81,8 +86,6 @@ GEM
     launchy (0.4.0)
       configuration (>= 0.0.5)
       rake (>= 0.8.1)
-    linecache19 (0.5.12)
-      ruby_core_source (>= 0.1.4)
     mail (2.3.0)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -172,16 +175,6 @@ GEM
       activesupport (~> 3.0)
       railties (~> 3.0)
       rspec (~> 2.6.0)
-    ruby-debug-base19 (0.11.25)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby_core_source (>= 0.1.4)
-    ruby-debug19 (0.11.6)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby-debug-base19 (>= 0.11.19)
-    ruby_core_source (0.1.5)
-      archive-tar-minitar (>= 0.5.2)
     rubyzip (0.9.4)
     rufus-scheduler (2.0.10)
       tzinfo (>= 0.3.23)
@@ -230,6 +223,7 @@ DEPENDENCIES
   capybara-webkit
   coffee-rails (~> 3.1.0)
   daemons
+  debugger
   haml
   hoptoad_notifier
   jquery-rails
@@ -245,7 +239,6 @@ DEPENDENCIES
   resque-retry
   ri_cal
   rspec-rails (~> 2.6)
-  ruby-debug19
   sass-rails (~> 3.1.0)
   simple_uuid
   uglifier

--- a/app/jobs/someone_declined.rb
+++ b/app/jobs/someone_declined.rb
@@ -1,0 +1,9 @@
+class SomeoneDeclined < Job
+  @queue = :high
+
+  def perform(attendance_id, declined_user_id)
+    attendance = Attendance.includes(:user, :event).find(attendance_id)
+    declined_user = User.find(declined_user_id)
+    AttendanceMailer.someone_declined_notification(attendance, declined_user).deliver
+  end
+end

--- a/app/mailers/attendance_mailer.rb
+++ b/app/mailers/attendance_mailer.rb
@@ -48,4 +48,15 @@ class AttendanceMailer < ActionMailer::Base
       :to      => attendance.recipient
     )
   end
+
+  def someone_declined_notification(attendance, traitor)
+    @attendance = attendance
+    @traitor = traitor
+    @event = attendance.event
+
+    mail(
+      :subject => t("attendance_mailer.someone_declined.subject", :event_name => @event.name, :traitor => @traitor.name),
+      :to      => attendance.recipient
+    )
+  end
 end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -69,6 +69,10 @@ class Attendance < ActiveRecord::Base
     state.trigger(:decline)
     save!(:validate => false)
 
+    event.attendances.confirmed.each do |attendance|
+      attendance.send_someone_declined_email(user)
+    end
+
     event.process_waitlist
   end
 
@@ -96,6 +100,10 @@ class Attendance < ActiveRecord::Base
 
   def send_event_cancelled_email
     NotifyEventCancelled.enqueue(id)
+  end
+
+  def send_someone_declined_email(user)
+    SomeoneDeclined.enqueue(id, user.id)
   end
 
   def send_new_comment_email

--- a/app/views/attendance_mailer/someone_declined_notification.es.text.erb
+++ b/app/views/attendance_mailer/someone_declined_notification.es.text.erb
@@ -1,0 +1,11 @@
+<%= t("email.generic.greeting") %>
+
+<%= @traitor.name %> se bajó del evento!
+
+<% if @event.start_at.to_date == Date.today %>
+  Que el grupo se haga cargo y le "enseñe" que no se cancela el mismo día. El castigo es merecido.
+  
+  El presente es la piedra.
+<% end %>
+
+<%= event_url(@event) %>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -309,6 +309,8 @@ es:
       subject: "Te han invitado a %{event_name}"
     new_comment_notification:
       subject: "Hay un nuevo comentario en el evento %{event_name}"
+    someone_declined:
+      subject: "%{traitor} se bajó de %{event_name}!!!"
 
   email:
     generic:


### PR DESCRIPTION
This way the group can find substitutes or rethink the event as soon as a "confirmed" user cancels. We can later add more control on this behavior.
